### PR TITLE
all: update library to allow testing of public interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,32 @@ This is a [Prometheus Collector](https://pkg.go.dev/github.com/prometheus/client
 
 ## Example Usage
 
-```
+```go
 package main
 
 import (
-    "log"
-    "http"
+	"context"
+	"log"
+	"net/http"
+	"os"
 
-    "github.com/prometheus/client_golang/prometheus"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-    "github.com/IBM/pgxpoolprometheus"
-
+	"github.com/IBM/pgxpoolprometheus"
 )
 
 func main() {
-    pool, err := pgxpool.Connect(context.Background(), os.Getenv("DATABASE_URL"))
-    if err != nil {
-        log.Fatal(err)
-    }
+	pool, err := pgxpool.Connect(context.Background(), os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    collector := pgxpoolprometheus.NewCollector(pool, map[string][string]{"db_name": "my_db"})
-    prometheus.MustRegister(collector)
+	collector := pgxpoolprometheus.NewCollector(pool, map[string]string{"db_name": "my_db"})
+	prometheus.MustRegister(collector)
 
-    http.Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 ```


### PR DESCRIPTION
This change removes some of the complexity in the
added interfaces and allows for testing the public
API as well as the conversion wrapper functions.

Signed-off-by: crozzy <joseph.crosland@gmail.com>